### PR TITLE
Add scrolling

### DIFF
--- a/vimari.safariextension/Settings.plist
+++ b/vimari.safariextension/Settings.plist
@@ -34,6 +34,26 @@
 	</dict>
 	<dict>
 		<key>DefaultValue</key>
+		<string>j</string>
+		<key>Key</key>
+		<string>scrollDown</string>
+		<key>Title</key>
+		<string>Scroll Down Toggle CTRL-</string>
+		<key>Type</key>
+		<string>TextField</string>
+	</dict>
+	<dict>
+		<key>DefaultValue</key>
+		<string>k</string>
+		<key>Key</key>
+		<string>scrollUp</string>
+		<key>Title</key>
+		<string>Scroll Up Toggle CTRL-</string>
+		<key>Type</key>
+		<string>TextField</string>
+	</dict>
+	<dict>
+		<key>DefaultValue</key>
 		<string>asdfjklqwerzxc</string>
 		<key>Key</key>
 		<string>linkHintCharacters</string>

--- a/vimari.safariextension/global.html
+++ b/vimari.safariextension/global.html
@@ -24,8 +24,10 @@
 			var settings = {
 				'linkHintCharacters' : safari.extension.settings.linkHintCharacters,
 				'hintToggle'         : safari.extension.settings.hintToggle,
-				'tabForward'         : safari.extension.settings.tabBack,
-				'tabBack'            : safari.extension.settings.tabForward
+				'tabForward'         : safari.extension.settings.tabForward,
+				'tabBack'            : safari.extension.settings.tabBack,
+				'scrollDown'         : safari.extension.settings.scrollDown,
+				'scrollUp'           : safari.extension.settings.scrollUp
 				};
 			// Send settings to injected page
 			safari.application.activeBrowserWindow.activeTab.page.dispatchMessage('setSettings', settings);

--- a/vimari.safariextension/injected.js
+++ b/vimari.safariextension/injected.js
@@ -58,6 +58,12 @@ function keyEvent(event) {
 		case s.tabBack       :
 					safari.self.tab.dispatchMessage('changeTab', 1);
 					break;
+		case s.scrollDown    :
+					window.scrollBy(0, 60);
+					break;
+		case s.scrollUp      :
+					window.scrollBy(0, -60);
+					break;
 	}
 
 	event.stopPropagation();


### PR DESCRIPTION
This commit adds basic scrolling functionality. The default bindings
are similar to the canonical Vim commands: 'CTRL-j' to scroll down
and 'CTRL-k' to scroll up. (These bindings are configurable.)

This also fixes a typo where the tabForward and tabBackward settings
were reversed.
