### PR TITLE
Stop Vimari from capturing capital letters in text fields

### DIFF
--- a/vimari.safariextension/mousetrap.js
+++ b/vimari.safariextension/mousetrap.js
@@ -253,7 +253,8 @@
         }
 
         // if the event has modifiers, no need to stop. Vimari-specific.
-        if (_eventModifiers(e).length !== 0) {
+        var modifiers = _eventModifiers(e);
+        if (modifiers.length !== 0 && !(modifiers.length === 1 && modifiers[0] === 'shift')) {
             return false;
         }
 


### PR DESCRIPTION
This fixes a bug where Vimari would capture key combinations involving only the SHIFT modifier in text areas. This behavior was added in commit:c2b3e0386297 and causes problems when typing capital letters if you have any Vimari commands configured which are only `shift+_`.
