### PR TITLE
Allow binding multiple keys to an action

### DIFF
--- a/vimari.safariextension/injected.js
+++ b/vimari.safariextension/injected.js
@@ -52,8 +52,8 @@ function bindKeyCodesToActions() {
 		Mousetrap.reset();
 		for (var actionName in actionMap) {
 			if (actionMap.hasOwnProperty(actionName)) {
-				var keyCode = getKeyCode(actionName);
-				Mousetrap.bind(keyCode, executeAction(actionName), 'keydown');
+				var keyCodes = getKeyCodes(actionName);
+				Mousetrap.bind(keyCodes, executeAction(actionName), 'keydown');
 			}
 		}
 	}
@@ -78,12 +78,21 @@ function unbindKeyCodes() {
 }
 
 // Adds an optional modifier to the configured key code for the action
-function getKeyCode(actionName) {
-	var keyCode = '';
+function getKeyCodes(actionName) {
+	var modifier = '';
+		keyCodes = settings[actionName].split(','),
+		acc = [],
+		i = 0;
+
 	if(settings.modifier) {
-		keyCode += settings.modifier + '+';
+		modifier += settings.modifier + '+';
 	}
-	return keyCode + settings[actionName];
+
+	for (i=0;i<keyCodes.length;i++) {
+		acc[i] = modifier + keyCodes[i].trim();
+	}
+
+	return acc;
 }
 
 


### PR DESCRIPTION
Keycode preferences can now be a comma-separated list of hotkeys, which
allows you to set multiple hotkeys to the same action.

This is useful if more than one hotkey makes sense, for example
'ctrl+d' and 'd', and you can't stop switching between them.
