### PR TITLE
Remove console.log calls

### DIFF
--- a/vimari.safariextension/injected.js
+++ b/vimari.safariextension/injected.js
@@ -209,11 +209,8 @@ function setActive(msg) {
 
 	extensionActive = msg;
 	if(msg) {
-		// Add event listener...
-		console.log('Enabling Vimari for this tab');
 		bindKeyCodesToActions();
 	} else {
-		console.log('Disabling Vimari for this tab');
 		unbindKeyCodes();
 	}
 }


### PR DESCRIPTION
It's difficult to debug my own code if I have vimari debug calls in safari's console.
