### PR TITLE
remove no needed 'ctrl' in settings

### DIFF
--- a/vimari.safariextension/Settings.plist
+++ b/vimari.safariextension/Settings.plist
@@ -78,7 +78,7 @@
 		<key>Key</key>
 		<string>scrollDownHalfPage</string>
 		<key>Title</key>
-		<string>Scroll Down Half Page CTRL-</string>
+		<string>Scroll Down Half Page</string>
 		<key>Type</key>
 		<string>TextField</string>
 	</dict>
@@ -88,7 +88,7 @@
 		<key>Key</key>
 		<string>scrollUpHalfPage</string>
 		<key>Title</key>
-		<string>Scroll Up Half Page CTRL-</string>
+		<string>Scroll Up Half Page</string>
 		<key>Type</key>
 		<string>TextField</string>
 	</dict>
@@ -98,7 +98,7 @@
 		<key>Key</key>
 		<string>goToPageTop</string>
 		<key>Title</key>
-		<string>Go to the top of the page CTRL-</string>
+		<string>Go to the top of the page</string>
 		<key>Type</key>
 		<string>TextField</string>
 	</dict>
@@ -108,7 +108,7 @@
 		<key>Key</key>
 		<string>goToPageBottom</string>
 		<key>Title</key>
-		<string>Go to the bottom of the page CTRL-</string>
+		<string>Go to the bottom of the page</string>
 		<key>Type</key>
 		<string>TextField</string>
 	</dict>


### PR DESCRIPTION
I found when you set the modifier key to nothing , there is no need to press the ctrl key with  u d gg or G  to do these scroll action ( safari 6.0.5 )

in my opinion it's just ok so  I removes the the 'Ctrl'  before the input field in the settings panel.
