### PR TITLE
Allow user to use 'ctrl+[' to enter normal mode

### DIFF
--- a/vimari.safariextension/injected.js
+++ b/vimari.safariextension/injected.js
@@ -61,7 +61,7 @@ var actionMap = {
 // Meant to be overridden, but still has to be copy/pasted from the original...
 Mousetrap.stopCallback = function(e, element, combo) {
 	// Escape key is special, no need to stop. Vimari-specific.
-	if (combo === 'esc') { return false; }
+	if (combo === 'esc' || combo === 'ctrl+[') { return false; }
 
   // Preserve the behavior of allowing ex. ctrl-j in an input
   if (settings.modifier) { return false; }
@@ -81,6 +81,7 @@ function bindKeyCodesToActions() {
 	if (topWindow) {
 		Mousetrap.reset();
 		Mousetrap.bind('esc', enterNormalMode);
+		Mousetrap.bind('ctrl+[', enterNormalMode);
 		Mousetrap.bind('i', enterInsertMode);
 		for (var actionName in actionMap) {
 			if (actionMap.hasOwnProperty(actionName)) {


### PR DESCRIPTION
The (control key + left square bracket) sequence is equivalent to pressing (esc) in vim, and can be used to avoid having to use the physically distant escape key. 

This behaviour occurs in Google Chrome's vimium as well.
