### PR TITLE
Added step size slider to Settings panel

### DIFF
--- a/vimari.safariextension/Info.plist
+++ b/vimari.safariextension/Info.plist
@@ -5,7 +5,7 @@
 	<key>Author</key>
 	<string>Various</string>
 	<key>Builder Version</key>
-	<string>7536.28.10</string>
+	<string>8537.71</string>
 	<key>CFBundleDisplayName</key>
 	<string>vimari</string>
 	<key>CFBundleExecutable</key>

--- a/vimari.safariextension/Settings.plist
+++ b/vimari.safariextension/Settings.plist
@@ -192,5 +192,21 @@
 		<key>Type</key>
 		<string>TextField</string>
 	</dict>
+	<dict>
+		<key>DefaultValue</key>
+		<real>60</real>
+		<key>Key</key>
+		<string>scrollSize</string>
+		<key>MaximumValue</key>
+		<real>200</real>
+		<key>MinimumValue</key>
+		<real>20</real>
+		<key>StepValue</key>
+		<real>20</real>
+		<key>Title</key>
+		<string>Scroll Size</string>
+		<key>Type</key>
+		<string>Slider</string>
+	</dict>
 </array>
 </plist>

--- a/vimari.safariextension/global.html
+++ b/vimari.safariextension/global.html
@@ -43,7 +43,8 @@
 				'goToPageTop'        : safari.extension.settings.goToPageTop,
 				'closeTab'	         : safari.extension.settings.closeTab,
 				'closeTabReverse'    : safari.extension.settings.closeTabReverse,
-				'modifier'           : safari.extension.settings.modifier
+				'modifier'           : safari.extension.settings.modifier,
+				'scrollSize'           : safari.extension.settings.scrollSize,
 			};
 
 			safari.application.activeBrowserWindow.tabs[getActiveTab()].page.dispatchMessage('setSettings', settings);

--- a/vimari.safariextension/injected.js
+++ b/vimari.safariextension/injected.js
@@ -42,16 +42,16 @@ var actionMap = {
 		safari.self.tab.dispatchMessage('changeTab', 0); },
 
 	'scrollDown' :
-		function() { window.scrollBy(0, 60); },
+		function() { window.scrollBy(0, settings.scrollSize); },
 
 	'scrollUp' :
-		function() { window.scrollBy(0, -60); },
+		function() { window.scrollBy(0, -settings.scrollSize); },
 
 	'scrollLeft' :
-		function() { window.scrollBy(-60, 0); },
+		function() { window.scrollBy(-settings.scrollSize, 0); },
 
 	'scrollRight' :
-		function() { window.scrollBy(60, 0); },
+		function() { window.scrollBy(settings.scrollSize, 0); },
 
 	'goBack' :
 		function() { window.history.back(); },


### PR DESCRIPTION
The step size of the the movement commands h/j/k/l are a bit too small for my taste (and possibly others). Rather than using a hardcoded value, I added a slider to the settings panel. It defaults to the old value of 60 and can move between 20 and 200 in steps of 20.
