### PR TITLE
Hint markers with flat styling

### DIFF
--- a/vimari.safariextension/injectedcss.css
+++ b/vimari.safariextension/injectedcss.css
@@ -45,20 +45,19 @@ div.internalVimiumHintMarker {
   white-space: nowrap !important;
   overflow: hidden !important;
   font-size: 11px !important;
-  padding: 1px 3px 0px 3px !important;
-  background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#FFF785), color-stop(100%,#FFC542)) !important;
-  border: 1px solid #E3BE23 !important;
-  border-radius: 3px !important;
-  box-shadow: 0px 3px 7px 0px rgba(0, 0, 0, 0.3) !important;
+  padding: 2px 3px !important;
+  background-color: #feda31 !important;
+  border: 0 !important;
+  border-radius: 2px !important;
+  box-shadow: inset 0 -2px 0 #b39922 !important;
 }
 
 div.internalVimiumHintMarker span {
-  color: #000000;
+  color: #4a400e;
   font-family: Helvetica, Arial, sans-serif;
   font-weight: bold;
-  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.6);	
 }
 
 div.internalVimiumHintMarker > .matchingCharacter {
-  color: #D4AC3A;
+  color: #dcbc2a;
 }


### PR DESCRIPTION
I recently updated my Vimium styles to use a more flat look for the hint markers and I just installed Vimari for Safari.

@guyht What do you think of using something like this as the default? (Note that these screenshots are from Vimium since I had trouble getting my Vimari fork working locally)

![](https://camo.githubusercontent.com/6e164c42becc71f33d22eee30cc972f6c3b95f6e/687474703a2f2f636c2e6c792f696d6167652f3144336732513041313733492f636f6e74656e74/content)

No worries if you don't like this look. If nothing else, would it be possible to expose CSS styling overrides like Vimium does?
