### PR TITLE
Reverse link hints so that nearby links have dissimilar hints

### DIFF
--- a/app_extension/vimari/extension/js/link-hints.js
+++ b/app_extension/vimari/extension/js/link-hints.js
@@ -346,7 +346,7 @@ function numberToHintString(number, numHintDigits) {
   var hintStringLength = hintString.length;
   for (var i = 0; i < numHintDigits - hintStringLength; i++)
     hintString.unshift(settings.linkHintCharacters[0]);
-  return hintString.join("");
+  return hintString.reverse().join("");
 }
 
 function simulateClick(link, openInNewTab) {


### PR DESCRIPTION
This matches the behaviour of Vimium, and makes it easier to type a link.

Fixes #77