### PR TITLE
Hide non-matching link hints

### DIFF
--- a/app_extension/vimari/extension/css/injected.css
+++ b/app_extension/vimari/extension/css/injected.css
@@ -39,7 +39,7 @@
 
 div.internalVimiumHintMarker {
   position: absolute !important;
-  display: block !important;
+  display: block;
   top: -1px;
   left: -1px;
   white-space: nowrap !important;


### PR DESCRIPTION
This change will hide any link hints which don't match the currently typed string.

I figured this out by diffing the current CSS with what Vimium is using. Oddly, Safari doesn't seem to show the `!important` declaration on any user stylesheets, so it took me a while to figure this out.

Longer term it might be good to pull more from Vimium's styling, but this is the smallest possible change to fix the immediate issues.

Fixes #79.

Here's an example showing HN after pressing "L" (note, the screenshot also has #130):

<img width="874" alt="Screenshot of Safari (10-04-19, 5-30-44 PM)" src="https://user-images.githubusercontent.com/811954/55853699-60ef9400-5bb6-11e9-961a-b8b014e7ef76.png">
