### PR TITLE
Ports closeTab and tab navigation for Safari 12 (macOS 10.14.4+ only)

### DIFF
--- a/app_extension/vimari/extension/SafariExtensionHandler.swift
+++ b/app_extension/vimari/extension/SafariExtensionHandler.swift
@@ -11,6 +11,7 @@ import SafariServices
 enum ActionType: String {
     case openLinkInTab
     case openNewTab
+    case closeTab
 }
 
 class SafariExtensionHandler: SFSafariExtensionHandler {
@@ -23,6 +24,9 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
             break
         case ActionType.openNewTab.rawValue:
             openNewTab()
+            break
+        case ActionType.closeTab.rawValue:
+            closeTab()
             break
         default:
             NSLog("Received message with unsupported type: \(messageName)")
@@ -47,6 +51,14 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
         })
     }
     
+    func closeTab() {
+        SFSafariApplication.getActiveWindow { (window) in
+            window?.getActiveTab(completionHandler: { (tab) in
+                tab?.close()
+            })
+        }
+    }
+
     override func toolbarItemClicked(in window: SFSafariWindow) {
         // This method will be called when your toolbar item is clicked.
         NSLog("The extension's toolbar item was clicked")

--- a/app_extension/vimari/extension/js/injected.js
+++ b/app_extension/vimari/extension/js/injected.js
@@ -37,10 +37,10 @@ var actionMap = {
 		activateLinkHintsMode(true, false); },
 
 	'tabForward': function() {
-		safari.self.tab.dispatchMessage('changeTab', 1); },
+		safari.extension.dispatchMessage('changeTab', {direction: 'forward'}); },
 
 	'tabBack': function() {
-		safari.self.tab.dispatchMessage('changeTab', 0); },
+		safari.extension.dispatchMessage('changeTab', {direction: 'backward'}); },
 
 	'scrollDown':
 		function() { window.scrollBy(0, settings.scrollSize); },

--- a/app_extension/vimari/extension/js/injected.js
+++ b/app_extension/vimari/extension/js/injected.js
@@ -67,10 +67,10 @@ var actionMap = {
 		function() { openNewTab(); },
 
 	'closeTab':
-		function() { safari.self.tab.dispatchMessage('closeTab', 0); },
+		function() { safari.extension.dispatchMessage('closeTab'); },
 
 	'closeTabReverse':
-		function() { safari.self.tab.dispatchMessage('closeTab', 1); },
+		function() { safari.extension.dispatchMessage('closeTab'); },
 
 	'scrollDownHalfPage':
 		function() { window.scrollBy(0, window.innerHeight / 2); },


### PR DESCRIPTION
Currently with Vimari 2.0 (for Safari 12), tab closing and tab navigation (i.e. move to the left/right tab don't seem to work. These commits port them to use the new native extension API. However, `[SFSafariTab close...]` and `[SFSafariWindow getAllTabs...]` are only available on macOS 10.14.4+. Sadly I haven't yet found a way to make those functionalities work for earlier versions of macOS.
 