### PR TITLE
Show HUD on entering normal or insert mode

### DIFF
--- a/Vimari Extension/js/injected.js
+++ b/Vimari Extension/js/injected.js
@@ -184,15 +184,26 @@ function enterNormalMode() {
 	// Clear link hints (if any)
 	deactivateLinkHintsMode();
 
+
+    if (insertMode === false) {
+        return // We are already in normal mode.
+    }
+
 	// Re-enable if in insert mode
 	insertMode = false;
+    HUD.showForDuration('Normal Mode', hudDuration);
+
 	Mousetrap.bind('i', enterInsertMode);
 }
 
 // Calling it 'insert mode', but it's really just a user-triggered
 // off switch for the actions.
 function enterInsertMode() {
-	insertMode = true;
+    if (insertMode === true) {
+        return // We are already in insert mode.
+    }
+    insertMode = true;
+    HUD.showForDuration('Insert Mode', hudDuration);
 	Mousetrap.unbind('i');
 }
 


### PR DESCRIPTION
As indicated in #176 we should be more transparent to the user about the current active mode (insert or normal). This PR uses the already existing HUD system to display a message to the user when entering either mode.

<img width="235" alt="Screenshot 2020-08-12 at 13 01 32" src="https://user-images.githubusercontent.com/7622933/90007978-f663d200-dc9b-11ea-9daf-e72958a01181.png">
<img width="235" alt="Screenshot 2020-08-12 at 13 01 26" src="https://user-images.githubusercontent.com/7622933/90007982-f6fc6880-dc9b-11ea-8359-5a0aa9202b00.png">

A more advanced system is being implemented by agbohub in #181 that could replace this later on.