### PR TITLE
Fix unexpected trigger for link-hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Changelog
 -------------
 
 ### Unreleased
+* Remove eager link hint triggering [#190](https://github.com/televator-apps/vimari/issues/190)
 * Add user customisation (based on the work of @nieldm [#163](https://github.com/televator-apps/vimari/pull/163)).
 * Update Vimari interface to allow users access to their configuration.
 * Remove `closeTabReverse` action.

--- a/Vimari Extension/js/link-hints.js
+++ b/Vimari Extension/js/link-hints.js
@@ -263,15 +263,17 @@ function onKeyUpInLinkHintsMode(event) {
 }
 
 /*
- * Updates the visibility of link hints on screen based on the keystrokes typed thus far. If only one
- * link hint remains, click on that link and exit link hints mode.
+ * Updates the visibility of link hints on screen based on the keystrokes typed
+ * thus far. If the provided keystrokes match exactly with one LinkHint, click
+ * on that link and exit link hints mode.
  */
 function updateLinkHints() {
+  var hintStringLength = hintMarkers[0].getAttribute("hintString").length
   var matchString = hintKeystrokeQueue.join("");
   var linksMatched = highlightLinkMatches(matchString);
-  if (linksMatched.length === 0)
+  if (linksMatched.length === 0) {
     deactivateLinkHintsMode();
-  else if (linksMatched.length === 1) {
+  } else if (linksMatched.length === 1 && matchString.length === hintStringLength) {
     var matchedLink = linksMatched[0];
     if (isSelectable(matchedLink)) {
       matchedLink.focus();


### PR DESCRIPTION
Resolves #190 

Taken from commit 947c45e:
```
As the link-hint matching algorithm quits eagerly, that is when there
are no other link hints matching the typed keystrokes, a user could
trigger a Vimari binding if the last link-hint-character was also a
binding.

This is possible when the linkHintsCharacters first character is also
assigned to one of the Vimari actions. This first character is used as
padding in link-hints.js:349-350 and could therefore end up at the end
of a link hint. Triggering the scenario above if the user types all
characters from the link hint while Vimari eagerly quits before the last
character is typed (because there are no other matches given all but the
last keystrokes).

This commit resolves this issue by removing the eager evaluation of link
hints, requiring the user to type all characters displayed. This
solution was chosen as it is the simplest and most intuitive for the end
user.

This does mean that the end user can be presented with a filtered set of
exactly 1 link hint. In the future we should adjust the link-hint
algorithm to allow for variably sized link-hints such that we remove
the need for padding. Therefore removing the situation where the user
ends up with exactly 1 link hint.
```