### PR TITLE
Use window.open for opening a new tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Changelog
 -------------
 
 ### Unreleased
+* Use `window.open` for `openNewTab` action [#189](https://github.com/televator-apps/vimari/issues/189)
 * Add user customisation (based on the work of @nieldm [#163](https://github.com/televator-apps/vimari/pull/163)).
 * Update Vimari interface to allow users access to their configuration.
 * Remove `closeTabReverse` action.

--- a/Vimari Extension/SafariExtensionHandler.swift
+++ b/Vimari Extension/SafariExtensionHandler.swift
@@ -2,7 +2,6 @@ import SafariServices
 
 enum ActionType: String {
     case openLinkInTab
-    case openNewTab
     case tabForward
     case tabBackward
     case closeTab
@@ -54,8 +53,6 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
         case .openLinkInTab:
             let url = URL(string: userInfo?["url"] as! String)
             openInNewTab(url: url!)
-        case .openNewTab:
-            openNewTab()
         case .tabForward:
             changeTab(withDirection: .forward, from: page)
         case .tabBackward:
@@ -89,19 +86,6 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
     private func openInNewTab(url: URL) {
         SFSafariApplication.getActiveWindow { activeWindow in
             activeWindow?.openTab(with: url, makeActiveIfPossible: false, completionHandler: { _ in
-                // Perform some action here after the page loads
-            })
-        }
-    }
-
-    private func openNewTab() {
-        var newPageUrl: String? = getSetting("openTabUrl") as? String
-        if newPageUrl == nil || newPageUrl!.isEmpty {
-            newPageUrl = Constant.newTabPageURL
-        }
-        let url = URL(string: newPageUrl!)!
-        SFSafariApplication.getActiveWindow { activeWindow in
-            activeWindow?.openTab(with: url, makeActiveIfPossible: true, completionHandler: { _ in
                 // Perform some action here after the page loads
             })
         }

--- a/Vimari Extension/js/SafariExtensionCommunicator.js
+++ b/Vimari Extension/js/SafariExtensionCommunicator.js
@@ -12,9 +12,6 @@ var SafariExtensionCommunicator = (function (msgHandler) {
     publicAPI.requestSettingsUpdate = function() {
         sendMessage("updateSettings")
     }
-    publicAPI.requestNewTab = function() {
-        sendMessage("openNewTab")
-    }
     publicAPI.requestTabForward = function() {
         sendMessage("tabForward")
     }

--- a/Vimari Extension/js/injected.js
+++ b/Vimari Extension/js/injected.js
@@ -65,7 +65,7 @@ var actionMap = {
 		function() { window.location.reload(); },
 
 	'openTab':
-		function() { extensionCommunicator.requestNewTab(); },
+		function() { window.open(settings.openTabUrl); },
 
 	'closeTab':
 	    function() { extensionCommunicator.requestCloseTab(); },


### PR DESCRIPTION
Resolves #189

This replaces the usage of the extension for this task, which removes the ability to open a new tab without making it active. However for the 'openTab' functionality this functionality does not seem appropriate anyway.

In return for this we get the ability to open URLs that do not conform to the requirement set by Apple's API. This includes URLs like `topsites://` and `about:blank`.