### PR TITLE
Transparent Normal Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Changelog
 -------------
 
 ### Unreleased
+* Add `transparentBindings` setting that allows the use of non-bound keys in normal mode ([#188](https://github.com/televator-apps/vimari/issues/188)).
 * Remove eager link hint triggering [#190](https://github.com/televator-apps/vimari/issues/190)
 * Use `window.open` for `openNewTab` action [#189](https://github.com/televator-apps/vimari/issues/189)
 * Add user customisation (based on the work of @nieldm [#163](https://github.com/televator-apps/vimari/pull/163)).

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ for HTML elements having cursor style set to "pointer".
 
 **Scroll Size** - How much each scroll will move on the page.
 
+**Transparent Bindings** - Instead of fully isolating all keybindings in normal mode, the transparent bindings setting (when enabled)  allows you to use all non-Vimari-bound keys to interact with the web page as if you were in insert mode.
+
 ### Keyboard Bindings
 
 #### In-page navigation

--- a/Vimari Extension/js/injected.js
+++ b/Vimari Extension/js/injected.js
@@ -230,7 +230,7 @@ function unbindKeyCodes() {
 function boundKeys() {
     var bindings = Object.values(settings.bindings)
         // Split multi-key bindings.
-        .flatMap(s => s.split("+"))
+        .flatMap(s => s.split(/\+| /i))
     bindings.push(settings.modifier)
     // Use a set to remove duplicates.
     return new Set(bindings)

--- a/Vimari Extension/js/injected.js
+++ b/Vimari Extension/js/injected.js
@@ -236,7 +236,7 @@ function boundKeys() {
     bindings.push(settings.modifier)
     bindings.push("i")
     bindings.push("Escape")
-    bindinsg.push("Control")
+    bindings.push("Control")
     bindings.push("[")
 
     // Use a set to remove duplicates.

--- a/Vimari Extension/js/injected.js
+++ b/Vimari Extension/js/injected.js
@@ -241,7 +241,19 @@ function boundKeys() {
 // prevent custom key behaviour implemented by the underlying website.
 function stopSitePropagation() {
     return function (e) {
-        if (boundKeys().has(e.key) && !insertMode && !isActiveElementEditable()) {
+        if (insertMode) {
+            // Never stop propagation in insert mode.
+            return
+        }
+
+        if (settings.transparentBindings === true) {
+            if (boundKeys().has(e.key) && !isActiveElementEditable()) {
+                // If we are in normal mode with transparentBindings enabled we
+                // should only stop propagation in an editable element or if the
+                // key is bound to a Vimari action.
+                e.stopPropagation()
+            }
+        } else if (!isActiveElementEditable()) {
             e.stopPropagation()
         }
     }

--- a/Vimari Extension/js/injected.js
+++ b/Vimari Extension/js/injected.js
@@ -231,7 +231,14 @@ function boundKeys() {
     var bindings = Object.values(settings.bindings)
         // Split multi-key bindings.
         .flatMap(s => s.split(/\+| /i))
+
+    // Manually add the modifier, i, esc, and ctr+[.
     bindings.push(settings.modifier)
+    bindings.push("i")
+    bindings.push("Escape")
+    bindinsg.push("Control")
+    bindings.push("[")
+
     // Use a set to remove duplicates.
     return new Set(bindings)
 }

--- a/Vimari Extension/js/injected.js
+++ b/Vimari Extension/js/injected.js
@@ -226,12 +226,22 @@ function unbindKeyCodes() {
     document.removeEventListener("keydown", stopSitePropagation);
 }
 
-// Stops propagation of keyboard events in normal mode.  Adding this
+// Returns all keys bound in the settings.
+function boundKeys() {
+    var bindings = Object.values(settings.bindings)
+        // Split multi-key bindings.
+        .flatMap(s => s.split("+"))
+    bindings.push(settings.modifier)
+    // Use a set to remove duplicates.
+    return new Set(bindings)
+}
+
+// Stops propagation of keyboard events in normal mode. Adding this
 // callback to the document using the useCapture flag allows us to
 // prevent custom key behaviour implemented by the underlying website.
 function stopSitePropagation() {
     return function (e) {
-        if (insertMode == false && !isActiveElementEditable()) {
+        if (boundKeys().has(e.key) && !insertMode && !isActiveElementEditable()) {
             e.stopPropagation()
         }
     }

--- a/Vimari Extension/json/defaultSettings.json
+++ b/Vimari Extension/json/defaultSettings.json
@@ -7,6 +7,7 @@
   "modifier": "",
   "smoothScroll": true,
   "scrollDuration": 25,
+  "transparentBindings": true,
   "bindings": {
       "hintToggle": "f",
       "newTabHintToggle": "shift+f",


### PR DESCRIPTION
Resolves #188

This PR implements a new option `transparentBindings` (better name suggestion welcome) that is by default set to `true`. When enabled this makes the isolation between normal mode and insert mode more transparent as it allows all non-Vimari bound keys to be sent to the website (as if you were in insert mode). Keys bound to Vimari will however still be isolated from the website until the user enters insert mode. 

As the isolation happens on a per-key basis all keys, even if they are part of a multi-key binding and do not occur alone in any other binding, are included. This means that even though by default <kbd>g</kbd> doesn't do anything in Vimari it is isolated because it is part of both <kbd>g</kbd>+<kbd>i</kbd>,<kbd>shift</kbd>+<kbd>g</kbd>, and <kbd>g</kbd>+<kbd>g</kbd>.

This is aimed at improving the usability and compatibility for people upgrading to Vimari 2.1 as mentioned in #188. If people prefer the full isolation they can disable the option.

