### PR TITLE
Multiple shorcut support

### DIFF
--- a/Vimari Extension/js/injected.js
+++ b/Vimari Extension/js/injected.js
@@ -230,7 +230,7 @@ function unbindKeyCodes() {
 function boundKeys() {
     var bindings = Object.values(settings.bindings)
         // Split multi-key bindings.
-        .flatMap(s => s.split("+"))
+        .flatMap(s => s.split(/\+| /i))
     bindings.push(settings.modifier)
     // Use a set to remove duplicates.
     return new Set(bindings)

--- a/Vimari Extension/js/injected.js
+++ b/Vimari Extension/js/injected.js
@@ -228,9 +228,16 @@ function unbindKeyCodes() {
 
 // Returns all keys bound in the settings.
 function boundKeys() {
+    const splitBinding = s => s.split(/\+| /i)
     var bindings = Object.values(settings.bindings)
         // Split multi-key bindings.
-        .flatMap(s => s.split(/\+| /i))
+        .flatMap(s => {
+            if (typeof s === "string" || s instanceof String) {
+                return splitBinding(s)
+            } else if (Array.isArray(s)) {
+                return s.flatMap(splitBinding)
+            }
+        })
 
     // Manually add the modifier, i, esc, and ctr+[.
     bindings.push(settings.modifier)
@@ -275,14 +282,24 @@ function isActiveElementEditable() {
 
 // Adds an optional modifier to the configured key code for the action
 function getKeyCode(actionName) {
-	var keyCode = '';
-    if (typeof settings != 'undefined') {
-        if(settings.modifier) {
-            keyCode += settings.modifier + '+';
-        }
-        return keyCode + settings["bindings"][actionName];
+    if (settings === undefined) {
+        return ''
     }
-	return keyCode;
+
+	var keyCode = settings["bindings"][actionName];
+    const addModifier = s => {
+        if (settings.modifier && settings.modifier.length > 0) {
+            return `${settings.modifier}+${s}`
+        } else {
+            return s
+        }
+    }
+
+    if (Array.isArray(keyCode)) {
+        return keyCode.map(addModifier)
+    } else {
+        return addModifier(keyCode)
+    }
 }
 
 

--- a/Vimari Extension/js/injected.js
+++ b/Vimari Extension/js/injected.js
@@ -236,7 +236,7 @@ function boundKeys() {
     bindings.push(settings.modifier)
     bindings.push("i")
     bindings.push("Escape")
-    bindinsg.push("Control")
+    bindings.push("Control")
     bindings.push("[")
 
     // Use a set to remove duplicates.

--- a/Vimari Extension/js/injected.js
+++ b/Vimari Extension/js/injected.js
@@ -241,7 +241,19 @@ function boundKeys() {
 // prevent custom key behaviour implemented by the underlying website.
 function stopSitePropagation() {
     return function (e) {
-        if (boundKeys().has(e.key) && !insertMode && !isActiveElementEditable()) {
+        if (insertMode) {
+            // Never stop propagation in insert mode.
+            return
+        }
+
+        if (settings.transparentBindings === true) {
+            if (boundKeys().has(e.key) && !isActiveElementEditable()) {
+                // If we are in normal mode with transparentBindings enabled we
+                // should only stop propagation in an editable element or if the
+                // key is bound to a Vimari action.
+                e.stopPropagation()
+            }
+        } else if (!isActiveElementEditable()) {
             e.stopPropagation()
         }
     }

--- a/Vimari Extension/js/injected.js
+++ b/Vimari Extension/js/injected.js
@@ -231,7 +231,14 @@ function boundKeys() {
     var bindings = Object.values(settings.bindings)
         // Split multi-key bindings.
         .flatMap(s => s.split(/\+| /i))
+
+    // Manually add the modifier, i, esc, and ctr+[.
     bindings.push(settings.modifier)
+    bindings.push("i")
+    bindings.push("Escape")
+    bindinsg.push("Control")
+    bindings.push("[")
+
     // Use a set to remove duplicates.
     return new Set(bindings)
 }

--- a/Vimari Extension/js/injected.js
+++ b/Vimari Extension/js/injected.js
@@ -226,12 +226,22 @@ function unbindKeyCodes() {
     document.removeEventListener("keydown", stopSitePropagation);
 }
 
-// Stops propagation of keyboard events in normal mode.  Adding this
+// Returns all keys bound in the settings.
+function boundKeys() {
+    var bindings = Object.values(settings.bindings)
+        // Split multi-key bindings.
+        .flatMap(s => s.split("+"))
+    bindings.push(settings.modifier)
+    // Use a set to remove duplicates.
+    return new Set(bindings)
+}
+
+// Stops propagation of keyboard events in normal mode. Adding this
 // callback to the document using the useCapture flag allows us to
 // prevent custom key behaviour implemented by the underlying website.
 function stopSitePropagation() {
     return function (e) {
-        if (insertMode == false && !isActiveElementEditable()) {
+        if (boundKeys().has(e.key) && !insertMode && !isActiveElementEditable()) {
             e.stopPropagation()
         }
     }

--- a/Vimari Extension/json/defaultSettings.json
+++ b/Vimari Extension/json/defaultSettings.json
@@ -7,6 +7,7 @@
   "modifier": "",
   "smoothScroll": true,
   "scrollDuration": 25,
+  "transparentBindings": true,
   "bindings": {
       "hintToggle": "f",
       "newTabHintToggle": "shift+f",


### PR DESCRIPTION
Resolves #187 

From 092f7ba693de04d7f4819df2ab49a48dbe0508a2:

```
This commit will allow values like `["shift+k","g g"]` for our bindings
without breaking support for current bindings like `"g g"`. This allows
users to set multiple bindings for a single action as requested in
#187.
```

An example config with multiple keys for some bindings:

```json
{
  ...
  "bindings": {
      "hintToggle": "f",
      "newTabHintToggle": "shift+f",
      "scrollUp": "k",
      "scrollDown": "j",
      "scrollLeft": "h",
      "scrollRight": "l",
      "scrollUpHalfPage": "u",
      "scrollDownHalfPage": "d",
      "goToPageTop": "g g",
      "goToPageBottom": "shift+g",
      "goToFirstInput": ["g i", "g f i"],
      "goBack": "shift+h",
      "goForward": "shift+l",
      "reload": ["r", "R"],
      "tabForward": ["w", "shift+>"],
      "tabBack": ["q", "shift+<"],
      "closeTab": ["x", "Q"],
      "openTab": ["t", "l"]
  }
}

```

~This builds upon the work from #194 so it will remain a draft PR until that is merged as the changes include both for now.~