### PR TITLE
Increase default scroll size

### DIFF
--- a/Vimari Extension/json/defaultSettings.json
+++ b/Vimari Extension/json/defaultSettings.json
@@ -2,7 +2,7 @@
   "excludedUrls": "",
   "linkHintCharacters": "asdfjklqwerzxc",
   "detectByCursorStyle": false,
-  "scrollSize": 50,
+  "scrollSize": 150,
   "openTabUrl": "https://duckduckgo.com/",
   "modifier": "",
   "smoothScroll": true,


### PR DESCRIPTION
As mentioned in #186 the default scroll size of `50px` seems rather low. To provide a better out of the box experience I changed the default to `150px`.