### PR TITLE
Introduce 'yt' binding to duplicate current tab

### DIFF
--- a/Vimari Extension/js/injected.js
+++ b/Vimari Extension/js/injected.js
@@ -70,6 +70,9 @@ var actionMap = {
 	'closeTab':
 	    function() { extensionCommunicator.requestCloseTab(); },
 
+	'duplicateTab':
+		function() { window.open(window.location.href); },
+
 	'scrollDownHalfPage':
 		function() { customScrollBy(0, window.innerHeight / 2); },
 

--- a/Vimari Extension/json/defaultSettings.json
+++ b/Vimari Extension/json/defaultSettings.json
@@ -26,6 +26,7 @@
       "tabForward": "w",
       "tabBack": "q",
       "closeTab": "x",
-      "openTab": "t"
+      "openTab": "t",
+      "duplicateTab": "y t"
   }
 }


### PR DESCRIPTION
Resolves issue #202 - Introduce 'yt' binding to duplicate current tab

You may need to remove your current `userSettings.json` and reload Vimari for this to take effect (Warning: this will erase any user created bindings you have added to your `userSettings.json` file)

Back up your current configuration to keep any settings you have added with this command in a terminal:

```bash
mv ~/Library/Containers/net.televator.Vimari.SafariExtension/Data/Library/Application\ Support/userSettings.json ~/Library/Containers/net.televator.Vimari.SafariExtension/Data/Library/Application\ Support/userSettings.json.bak
```

This will also prompt Vimari to regenerate the userSettings file with the added `yt` binding. You may now add your old bindings from your user settings if you created any.

Reload Vimari for changes to take effect