### PR TITLE
Edit files in the user's preferred application if possible

### DIFF
--- a/Vimari Extension/ConfigurationModel.swift
+++ b/Vimari Extension/ConfigurationModel.swift
@@ -30,18 +30,32 @@ class ConfigurationModel: ConfigurationModelProtocol {
     
     func editConfigFile() throws {
         let settingsFilePath = try findOrCreateUserSettings()
-        NSWorkspace.shared.openFile(
-            settingsFilePath,
-            withApplication: Constant.defaultEditor
-        )
+        openFileInPreferredEditor(filePath: settingsFilePath)
     }
     
     func resetConfigFile() throws {
         let settingsFilePath = try overwriteUserSettings()
-        NSWorkspace.shared.openFile(
-            settingsFilePath,
-            withApplication: Constant.defaultEditor
-        )
+        openFileInPreferredEditor(filePath: settingsFilePath)
+    }
+
+    func openFileInPreferredEditor(filePath: String) {
+        let fileUrl = URL(fileURLWithPath: filePath)
+        let app = NSWorkspace.shared.urlForApplication(toOpen: fileUrl)
+
+        if #available(OSXApplicationExtension 10.15, *), let app = app {
+            NSLog("opening \(fileUrl) with \(String(describing: app))")
+
+            let config = NSWorkspace.OpenConfiguration()
+            config.promptsUserIfNeeded = true
+
+            NSWorkspace.shared.open([fileUrl], withApplicationAt: app, configuration: config, completionHandler: nil)
+        } else {
+            // Fallback on earlier versions
+            NSWorkspace.shared.openFile(
+                filePath,
+                withApplication: Constant.defaultEditor
+            )
+        }
     }
     
     func getDefaultSettings() throws -> [String : Any] {


### PR DESCRIPTION
See #213

This change should open userSettings.json in whatever app the user has configured; by default this seems to be Xcode, but since users can change this to whatever they prefer at the system level it feels like a better solution than forcing a specific app, like looking for the bundle ID of MacVim or just using something known installed, like TextEdit.

If we can't figure out an app to use, we still fallback to TextEdit.
