### PR TITLE
Added new setting excludedUrlsRegex

### DIFF
--- a/Vimari Extension/js/injected.js
+++ b/Vimari Extension/js/injected.js
@@ -354,7 +354,7 @@ function setSettings(msg) {
 
 function activateExtension(settings) {
     if ((typeof settings != "undefined") &&
-        isExcludedUrl(settings.excludedUrls, document.URL)) {
+        isExcludedUrl(settings.excludedUrls, settings.excludedUrlsRegex, document.URL)) {
         return;
     }
 
@@ -363,22 +363,28 @@ function activateExtension(settings) {
     bindKeyCodesToActions(settings);
 }
 
-function isExcludedUrl(storedExcludedUrls, currentUrl) {
-	if (!storedExcludedUrls.length) {
-		return false;
-	}
+function isExcludedUrl(storedExcludedUrls, storedExcludedUrlsRegex, currentUrl) {
+	if (storedExcludedUrls.length > 0) {
+        var excludedUrls, regexp, url, formattedUrl, _i, _len;
+        excludedUrls = storedExcludedUrls.split(",");
+        for (_i = 0, _len = excludedUrls.length; _i < _len; _i++) {
+            url = excludedUrls[_i];
+            formattedUrl = stripProtocolAndWww(url);
+            formattedUrl = formattedUrl.toLowerCase().trim();
+            regexp = new RegExp('((.*)?(' + formattedUrl + ')+(.*))');
+            if (currentUrl.toLowerCase().match(regexp)) {
+                return true;
+            }
+        }
+    }
 
-    var excludedUrls, regexp, url, formattedUrl, _i, _len;
-    excludedUrls = storedExcludedUrls.split(",");
-    for (_i = 0, _len = excludedUrls.length; _i < _len; _i++) {
-        url = excludedUrls[_i];
-        formattedUrl = stripProtocolAndWww(url);
-        formattedUrl = formattedUrl.toLowerCase().trim();
-        regexp = new RegExp('((.*)?(' + formattedUrl + ')+(.*))');
-        if (currentUrl.toLowerCase().match(regexp)) {
+    if (storedExcludedUrlsRegex.length > 0) {
+        var regexp = new RegExp(storedExcludedUrlsRegex, 'i');
+        if (currentUrl.match(regexp)) {
             return true;
         }
     }
+
     return false;
 }
 

--- a/Vimari Extension/json/defaultSettings.json
+++ b/Vimari Extension/json/defaultSettings.json
@@ -1,5 +1,6 @@
 {
   "excludedUrls": "",
+  "excludedUrlsRegex": "",
   "linkHintCharacters": "asdfjklqwerzxc",
   "detectByCursorStyle": false,
   "scrollSize": 150,

--- a/tests/vimari.spec.js
+++ b/tests/vimari.spec.js
@@ -1,92 +1,156 @@
 const expect = require('expect.js');
 
-describe('isExcludedUrl', () => {
+describe('isExcludedUrl with excludedUrls', () => {
     const isExcludedUrl = window.isExcludedUrl;
 
     it('returns true on same exact domain', () => {
         const excludedUrl = 'specific-domain.com';
         const currentUrl = excludedUrl;
-        expect(isExcludedUrl(excludedUrl, currentUrl)).to.be.ok();
+        expect(isExcludedUrl(excludedUrl, '', currentUrl)).to.be.ok();
     });
 
     it('returns true on duplicate domains', () => {
         const excludedUrls = 'specific-domain.com,specific-domain.com';
         const currentUrl = 'specific-domain.com';
-        expect(isExcludedUrl(excludedUrls, currentUrl)).to.be.ok();
+        expect(isExcludedUrl(excludedUrls, '', currentUrl)).to.be.ok();
     });
 
     it('returns true if any domain match', () => {
         const excludedUrls = 'different-domain.com,specific-domain.com';
         const currentUrl = 'specific-domain.com';
-        expect(isExcludedUrl(excludedUrls, currentUrl)).to.be.ok();
+        expect(isExcludedUrl(excludedUrls, '', currentUrl)).to.be.ok();
     });
 
     it('returns true on comma separated domains', () => {
         const excludedUrls = 'specific-domain.com,different-domain.com';
         const currentUrl = 'specific-domain.com';
-        expect(isExcludedUrl(excludedUrls, currentUrl)).to.be.ok();
+        expect(isExcludedUrl(excludedUrls, '', currentUrl)).to.be.ok();
     });
 
     it('returns false on different domain', () => {
         const excludedUrl = 'www.different-domain.com';
         const currentUrl = 'specific-domain.com';
-        expect(isExcludedUrl(excludedUrl, currentUrl)).to.not.be.ok();
+        expect(isExcludedUrl(excludedUrl, '', currentUrl)).to.not.be.ok();
     });
 
     it('returns false if no domains match', () => {
         const excludedUrls = 'www.different-domain.com,www.different-domain-2.com';
         const currentUrl = 'specific-domain.com';
-        expect(isExcludedUrl(excludedUrls, currentUrl)).to.not.be.ok();
+        expect(isExcludedUrl(excludedUrls, '', currentUrl)).to.not.be.ok();
     });
 
     it('returns false on space separated domains', () => {
         const excludedUrls = 'specific-domain.com different-domain.com';
         const currentUrl = 'specific-domain.com';
-        expect(isExcludedUrl(excludedUrls, currentUrl)).to.not.be.ok();
+        expect(isExcludedUrl(excludedUrls, '', currentUrl)).to.not.be.ok();
     });
 
     it('returns true on string added in front of current URL', () => {
         const excludedUrl = 'specific-domain.com';
         const currentUrl = 'http://specific-domain.com';
-        expect(isExcludedUrl(excludedUrl, currentUrl)).to.be.ok();
+        expect(isExcludedUrl(excludedUrl, '', currentUrl)).to.be.ok();
     });
 
     it('returns true on string appended to current URL', () => {
         const excludedUrl = 'specific-domain.com';
         const currentUrl = 'specific-domain.com/arbitrary-string';
-        expect(isExcludedUrl(excludedUrl, currentUrl)).to.be.ok();
+        expect(isExcludedUrl(excludedUrl, '', currentUrl)).to.be.ok();
     });
 
     it('returns true on string added on both sides of current URL', () => {
         const excludedUrl = 'specific-domain.com';
         const currentUrl = 'http://specific-domain.com/arbitrary-string';
-        expect(isExcludedUrl(excludedUrl, currentUrl)).to.be.ok();
+        expect(isExcludedUrl(excludedUrl, '', currentUrl)).to.be.ok();
     });
 
     it('returns true if current URL is less specific than excluded domain', () => {
         let excludedUrl = 'http://specific-domain.com';
         let currentUrl = 'specific-domain.com';
-        expect(isExcludedUrl(excludedUrl, currentUrl)).to.be.ok();
+        expect(isExcludedUrl(excludedUrl, '', currentUrl)).to.be.ok();
 
         excludedUrl = 'http://www.specific-domain.com';
         currentUrl = 'specific-domain.com';
-        expect(isExcludedUrl(excludedUrl, currentUrl)).to.be.ok();
+        expect(isExcludedUrl(excludedUrl, '', currentUrl)).to.be.ok();
     });
 
     it('returns true if current URL with appended string is less specific than excluded domain', () => {
         const excludedUrl = 'http://specific-domain.com';
         const currentUrl = 'specific-domain.com/arbitrary-string';
-        expect(isExcludedUrl(excludedUrl, currentUrl)).to.be.ok();
+        expect(isExcludedUrl(excludedUrl, '', currentUrl)).to.be.ok();
     });
 
     it('returns true even though cases doesn\'t match', () => {
         let excludedUrl = 'SPECIFIC-DOMAIN.com';
         let currentUrl = 'specific-domain.com';
-        expect(isExcludedUrl(excludedUrl, currentUrl)).to.be.ok();
+        expect(isExcludedUrl(excludedUrl, '', currentUrl)).to.be.ok();
 
         excludedUrl = 'specific-domain.com';
         currentUrl = 'SPECIFIC-DOMAIN.com';
-        expect(isExcludedUrl(excludedUrl, currentUrl)).to.be.ok();
+        expect(isExcludedUrl(excludedUrl, '', currentUrl)).to.be.ok();
+    });
+});
+
+describe('isExcludedUrl with excludedUrlsRegex', () => {
+    const isExcludedUrl = window.isExcludedUrl;
+
+    it('returns true on same exact domain', () => {
+        const excludedUrl = '^https://specific-domain\\.com/';
+        const currentUrl = 'https://specific-domain.com/';
+        expect(isExcludedUrl('', excludedUrl, currentUrl)).to.be.ok();
+    });
+
+    it('returns true on string appended to current URL', () => {
+        const excludedUrl = '^https://specific-domain\\.com/';
+        const currentUrl = 'https://specific-domain.com/foo';
+        expect(isExcludedUrl('', excludedUrl, currentUrl)).to.be.ok();
+    });
+
+    it('returns true on duplicate domains', () => {
+        const excludedUrls = '^https://(specific-domain\\.com|specific-domain\\.com)/';
+        const currentUrl = 'https://specific-domain.com/foo';
+        expect(isExcludedUrl('', excludedUrls, currentUrl)).to.be.ok();
+    });
+
+    it('returns true if any domain match', () => {
+        const excludedUrls = '^https://(specific-domain|other-domain)\\.com/';
+        const currentUrl = 'https://specific-domain.com/foo';
+        expect(isExcludedUrl('', excludedUrls, currentUrl)).to.be.ok();
+    });
+
+    it('returns false on different domain', () => {
+        const excludedUrl = '^https://www\\.different-domain\\.com';
+        const currentUrl = 'https://specific-domain.com/';
+        expect(isExcludedUrl('', excludedUrl, currentUrl)).to.not.be.ok();
+    });
+
+    it('returns false if does not match right pattern', () => {
+        const excludedUrls = '^https://blah\\.com/';
+        const currentUrl = 'https://foo.com/https://blah.com';
+        expect(isExcludedUrl('', excludedUrls, currentUrl)).to.not.be.ok();
+    });
+
+    it('returns true on string added on both sides of current URL', () => {
+        const excludedUrl = 'specific-domain.com';
+        const currentUrl = 'http://specific-domain.com/arbitrary-string';
+        expect(isExcludedUrl('', excludedUrl, currentUrl)).to.be.ok();
+    });
+
+    it('returns true if current URL is less specific than excluded domain', () => {
+        let excludedUrl = '^http://(www\\.)?specific-domain\\.com/';
+        let currentUrl = 'http://specific-domain.com/';
+        expect(isExcludedUrl('', excludedUrl, currentUrl)).to.be.ok();
+        currentUrl = 'http://www.specific-domain.com/';
+        expect(isExcludedUrl('', excludedUrl, currentUrl)).to.be.ok();
+    });
+
+    it('returns true even though cases doesn\'t match', () => {
+        let excludedUrl = '^https://SPECIFIC-DOMAIN\\.com/';
+        let currentUrl = 'https://specific-domain.com/';
+        expect(isExcludedUrl('', excludedUrl, currentUrl)).to.be.ok();
+
+        excludedUrl = '^https://specific-domain\\.com/';
+        currentUrl = 'https://SPECIFIC-DOMAIN.com/';
+        expect(isExcludedUrl('', excludedUrl, currentUrl)).to.be.ok();
     });
 });
 


### PR DESCRIPTION
Given the number of questions/issues about excludedUrls (#234, #225) and also the fact that the matching is pretty crude, here's a proposed PR for an `excludedUrlsRegex` setting which should be more straightforward for users familiar with regular expressions.

```
"excludedUrls": "a.com,b.com",
```

can be encoded as

```
"excludedUrlsRegex": "^https?://(a|b)\.com/",
```

and whether or not `foo.a.com` is matched or not can now be controlled with the setting above (not matching) or the setting below (matching):

```
"excludedUrlsRegex": "^https?://([^/]+\.)?(a|b)\.com/",
```